### PR TITLE
Code review amendments

### DIFF
--- a/ckanext/datarequests/templates/datarequests/snippets/additional_info.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/additional_info.html
@@ -22,14 +22,14 @@
         {% if datarequest.closed %}
           {% if h.closing_circumstances_enabled %}
             <tr>
-              <th scope="row" class="dataset-label">{{ _('Close Circumstance') }}</th>
+              <th scope="row" class="dataset-label">{{ _('Close circumstance') }}</th>
               <td class="dataset-details" title="{{ datarequest.close_circumstance }}">
                 {{ datarequest.close_circumstance if datarequest.close_circumstance else _('None') }}
               </td>
             </tr>
             {% if datarequest.approx_publishing_date %}
               <tr>
-                <th scope="row" class="dataset-label">{{ _('Approximate Publishing Date') }}</th>
+                <th scope="row" class="dataset-label">{{ _('Approximate publishing date') }}</th>
                 <td class="dataset-details" title="{{ datarequest.approx_publishing_date }}">
                   {{ h.render_datetime(datarequest.approx_publishing_date) }}
                 </td>
@@ -37,7 +37,7 @@
             {% endif %}
             {% if datarequest.accepted_dataset %}
               <tr>
-                <th scope="row" class="dataset-label">{{ _('Accepted Dataset') }}</th>
+                <th scope="row" class="dataset-label">{{ _('Accepted dataset') }}</th>
                 <td class="dataset-details">
                   {% link_for datarequest.accepted_dataset['title'], controller='package', action='read', id=datarequest.accepted_dataset.get('id') %}
                 </td>
@@ -45,7 +45,7 @@
             {% endif %}
           {% else %}
             <tr>
-              <th scope="row" class="dataset-label">{{ _('Accepted Dataset') }}</th>
+              <th scope="row" class="dataset-label">{{ _('Accepted dataset') }}</th>
               <td class="dataset-details">
               {% if datarequest.accepted_dataset %}
                 {% link_for datarequest.accepted_dataset['title'], controller='package', action='read', id=datarequest.accepted_dataset.get('id') %}

--- a/ckanext/datarequests/templates/datarequests/snippets/close_datarequest_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/close_datarequest_form.html
@@ -26,7 +26,7 @@
             </select>
           </div>
         </div>
-        {{ form.input('approx_publishing_date', id='field-approx_publishing_date', label=_('Approximate Publishing Date'), placeholder="yyyy-mm-dd", type='date', error=errors.approx_publishing_date) }}
+        {{ form.input('approx_publishing_date', id='field-approx_publishing_date', label=_('Approximate publishing date'), placeholder="yyyy-mm-dd", type='date', error=errors.approx_publishing_date) }}
       {% endif %}
   {% endblock %}
 

--- a/ckanext/datarequests/validator.py
+++ b/ckanext/datarequests/validator.py
@@ -84,7 +84,7 @@ def validate_datarequest_closing(context, request_data):
         try:
             tk.get_validator('package_name_exists')(accepted_dataset_id, context)
         except Exception:
-            raise tk.ValidationError({tk._('Accepted dataset'): [tk._('Dataset not found')]})
+            raise tk.ValidationError({tk._('Accepted Dataset'): [tk._('Dataset not found')]})
 
 
 def validate_comment(context, request_data):

--- a/test/features/datarequest_circumstances.feature
+++ b/test/features/datarequest_circumstances.feature
@@ -114,7 +114,7 @@ Feature: Datarequest-circumstances
         # Have to use JS to change the selected value as the behaving framework does not work with autocomplete dropdown
         Then I execute the script "document.getElementById('field-accepted_dataset_id').value = document.getElementById('field-accepted_dataset_id').options[1].value" 
         And I press the element with xpath "//button[contains(string(), 'Close data request')]"
-        Then I should see "Accepted Dataset" within 1 seconds 
+        Then I should see "Accepted dataset" within 1 seconds 
         And I should see "A Wonderful Story" within 1 seconds 
         
         Examples: Users  
@@ -137,13 +137,14 @@ Feature: Datarequest-circumstances
         | SysAdmin              |
         | DataRequestOrgAdmin   |
 
+    @wip
     Scenario Outline: Data request creator, Sysadmin and Admin users, when I close a datarequest with closing circumstance 'Requestor initiated closure', the circumstance should be visible on the datarequest page
         Given "<User>" as the persona
         When I log in and create a datarequest 
         And I press the element with xpath "//a[contains(string(), 'Close')]"
         And I select "Requestor initiated closure" from "close_circumstance" 
         And I press the element with xpath "//button[contains(string(), 'Close data request')]"
-        Then I should see "Close Circumstance" within 1 seconds 
+        Then I should see "Close circumstance" within 1 seconds 
         Then I should see "Requestor initiated closure" within 1 seconds 
         
         Examples: Users  
@@ -158,7 +159,7 @@ Feature: Datarequest-circumstances
         And I press the element with xpath "//a[contains(string(), 'Close')]"
         And I select "Requestor initiated closure" from "close_circumstance" 
         And I press the element with xpath "//button[contains(string(), 'Close data request')]"
-        Then I should not see "Accepted Dataset" within 1 seconds 
+        Then I should not see "Accepted dataset" within 1 seconds 
         Then I should not see "Approximate publishing date" within 1 seconds 
         
         Examples: Users  

--- a/test/features/datarequest_circumstances.feature
+++ b/test/features/datarequest_circumstances.feature
@@ -130,7 +130,7 @@ Feature: Datarequest-circumstances
         And I select "To be released as open data at a later date" from "close_circumstance" 
         And I fill in "approx_publishing_date" with "2025-06-01"
         And I press the element with xpath "//button[contains(string(), 'Close data request')]"
-        Then I should see "Approximate Publishing Date" within 1 seconds 
+        Then I should see "Approximate publishing date" within 1 seconds 
         
         Examples: Users  
         | User                  |
@@ -152,14 +152,14 @@ Feature: Datarequest-circumstances
         | DataRequestOrgAdmin   |
 
 
-    Scenario Outline: Data request creator, Sysadmin and Admin users, when I close a datarequest with no accepted dataset or Approximate publishing date, they should not be visibe on datarequest page
+    Scenario Outline: Data request creator, Sysadmin and Admin users, when I close a datarequest with no accepted dataset or Approximate publishing date, they should not be visible on datarequest page
         Given "<User>" as the persona
         When I log in and create a datarequest 
         And I press the element with xpath "//a[contains(string(), 'Close')]"
         And I select "Requestor initiated closure" from "close_circumstance" 
         And I press the element with xpath "//button[contains(string(), 'Close data request')]"
         Then I should not see "Accepted Dataset" within 1 seconds 
-        Then I should not see "Approximate Publishing Date" within 1 seconds 
+        Then I should not see "Approximate publishing date" within 1 seconds 
         
         Examples: Users  
         | User                  |


### PR DESCRIPTION
[DQL2-31]
- Fixed sentence casing
- Added validation for 'Approximate publishing date' date format. This is required as Safari does not support date inputs and falls back to using a textbox.