### PR TITLE
[QCDP24-26] show the datarequest created by current user after user moved to diff org

### DIFF
--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -469,10 +469,10 @@ def list_datarequests(context, data_dict):
     tk.check_access(constants.LIST_DATAREQUESTS, context, data_dict)
 
     # Get the organization
-    organization_id = data_dict.get('organization_id', None)
-    if organization_id:
+    requesting_organisation = data_dict.get('organization_id', None)
+    if requesting_organisation:
         # Get organization ID (organization name is received sometimes)
-        organization_id = organization_show({'ignore_auth': True}, {'id': organization_id}).get('id')
+        requesting_organisation = organization_show({'ignore_auth': True}, {'id': requesting_organisation}).get('id')
 
     user_id = data_dict.get('user_id', None)
     if user_id:
@@ -493,7 +493,7 @@ def list_datarequests(context, data_dict):
         desc = True
 
     # Call the function
-    db_datarequests = db.DataRequest.get_ordered_by_date(organization_id=organization_id,
+    db_datarequests = db.DataRequest.get_ordered_by_date(requesting_organisation=requesting_organisation,
                                                          user_id=user_id, status=status,
                                                          q=q, desc=desc)
 
@@ -514,24 +514,24 @@ def list_datarequests(context, data_dict):
         'Assign to Internal Data Catalogue Support': 0
     }
     for data_req in db_datarequests:
-        organization_id = data_req.organization_id
+        requesting_organisation = data_req.requesting_organisation
         status = data_req.status
 
-        if organization_id:
-            no_processed_organization_facet[organization_id] = no_processed_organization_facet.get(organization_id, 0) + 1
+        if requesting_organisation:
+            no_processed_organization_facet[requesting_organisation] = no_processed_organization_facet.get(requesting_organisation, 0) + 1
 
         if status in no_processed_status_facet:
             no_processed_status_facet[status] += 1
 
     # Format facets
     organization_facet = []
-    for organization_id in no_processed_organization_facet:
+    for requesting_organisation in no_processed_organization_facet:
         try:
-            organization = organization_show({'ignore_auth': True}, {'id': organization_id})
+            organization = organization_show({'ignore_auth': True}, {'id': requesting_organisation})
             organization_facet.append({
                 'name': organization.get('name'),
                 'display_name': organization.get('display_name'),
-                'count': no_processed_organization_facet[organization_id]
+                'count': no_processed_organization_facet[requesting_organisation]
             })
         except Exception:
             pass

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -469,7 +469,7 @@ def list_datarequests(context, data_dict):
     tk.check_access(constants.LIST_DATAREQUESTS, context, data_dict)
 
     # Get the organization
-    requesting_organisation = data_dict.get('organization_id', None)
+    requesting_organisation = data_dict.get('requesting_organisation', None)
     if requesting_organisation:
         # Get organization ID (organization name is received sometimes)
         requesting_organisation = organization_show({'ignore_auth': True}, {'id': requesting_organisation}).get('id')
@@ -524,11 +524,11 @@ def list_datarequests(context, data_dict):
             no_processed_status_facet[status] += 1
 
     # Format facets
-    organization_facet = []
+    requesting_organization_facet = []
     for requesting_organisation in no_processed_organization_facet:
         try:
             organization = organization_show({'ignore_auth': True}, {'id': requesting_organisation})
-            organization_facet.append({
+            requesting_organization_facet.append({
                 'name': organization.get('name'),
                 'display_name': organization.get('display_name'),
                 'count': no_processed_organization_facet[requesting_organisation]
@@ -552,8 +552,8 @@ def list_datarequests(context, data_dict):
     }
 
     # Facets can only be included if they contain something
-    if organization_facet:
-        result['facets']['organization'] = {'items': organization_facet}
+    if requesting_organization_facet:
+        result['facets']['requesting_organisation'] = {'items': requesting_organization_facet}
 
     if status_facet:
         result['facets']['status'] = {'items': status_facet}

--- a/ckanext/datarequests/controllers/controller_functions.py
+++ b/ckanext/datarequests/controllers/controller_functions.py
@@ -58,7 +58,7 @@ def _get_context():
             'user': c.user, 'auth_user_obj': c.userobj}
 
 
-def _show_index(user_id, organization_id, include_organization_facet, url_func, file_to_render, extra_vars=None):
+def _show_index(user_id, requesting_organisation, include_organization_facet, url_func, file_to_render, extra_vars=None):
     def pager_url(status=None, sort=None, q=None, page=None):
         params = []
 
@@ -88,8 +88,8 @@ def _show_index(user_id, organization_id, include_organization_facet, url_func, 
         if q:
             data_dict['q'] = q
 
-        if organization_id:
-            data_dict['organization_id'] = organization_id
+        if requesting_organisation:
+            data_dict['requesting_organisation'] = requesting_organisation
 
         if user_id:
             data_dict['user_id'] = user_id
@@ -105,7 +105,7 @@ def _show_index(user_id, organization_id, include_organization_facet, url_func, 
         c.filters = [(tk._('Newest'), 'desc'), (tk._('Oldest'), 'asc')]
         c.sort = sort
         c.q = q
-        c.organization = organization_id
+        c.requesting_organisation = requesting_organisation
         c.status = status
         c.datarequest_count = datarequests_list['count']
         c.datarequests = datarequests_list['result']
@@ -123,14 +123,14 @@ def _show_index(user_id, organization_id, include_organization_facet, url_func, 
 
         # Organization facet cannot be shown when the user is viewing an org
         if include_organization_facet is True:
-            c.facet_titles['organization'] = tk._('Organizations')
+            c.facet_titles['requesting_organisation'] = tk._('Organizations')
 
         if not extra_vars:
             extra_vars = {}
         extra_vars['filters'] = c.filters
         extra_vars['sort'] = c.sort
         extra_vars['q'] = c.q
-        extra_vars['organization'] = c.organization
+        extra_vars['requesting_organisation'] = c.requesting_organisation
         extra_vars['status'] = c.status
         extra_vars['datarequest_count'] = c.datarequest_count
         extra_vars['datarequests'] = c.datarequests
@@ -141,7 +141,7 @@ def _show_index(user_id, organization_id, include_organization_facet, url_func, 
             extra_vars['user'] = None
         if 'user_dict' not in extra_vars:
             extra_vars['user_dict'] = None
-        extra_vars['group_type'] = 'organization'
+        extra_vars['group_type'] = 'requesting_organisation'
         return tk.render(file_to_render, extra_vars=extra_vars)
     except ValueError as e:
         # This exception should only occur if the page value is not valid
@@ -153,7 +153,7 @@ def _show_index(user_id, organization_id, include_organization_facet, url_func, 
 
 
 def index():
-    return _show_index(None, request_helpers.get_first_query_param('organization', ''), True, search_url,
+    return _show_index(None, request_helpers.get_first_query_param('requesting_organisation', ''), True, search_url,
                        'datarequests/index.html')
 
 

--- a/ckanext/datarequests/templates/datarequests/index.html
+++ b/ckanext/datarequests/templates/datarequests/index.html
@@ -4,7 +4,7 @@
   <section class="module">
     <div class="module-content">
       {% block page_primary_action %}
-        {% snippet 'snippets/custom_search_form.html', query=q, fields=(('organization', organization), ('state', state)), sorting=filters, sorting_selected=sort, placeholder=_('Search Data Requests...'), no_bottom_border=true, count=datarequest_count, no_title=True %}
+        {% snippet 'snippets/custom_search_form.html', query=q, fields=(('requesting_organisation', requesting_organisation), ('state', state)), sorting=filters, sorting_selected=sort, placeholder=_('Search Data Requests...'), no_bottom_border=true, count=datarequest_count, no_title=True %}
         {{ h.snippet('datarequests/snippets/datarequest_list.html', datarequest_count=datarequest_count, datarequests=datarequests, page=page, q=q)}}
       {% endblock %}
     </div>


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/QCDP24-26

the AC says, the facet will be the user's orgs, which mean it should be the `requesting_organisation` field instead of `organization_id`, the last PR was mentioning the other way around (and it was not fully tested yet)

the `organization_id` field is populated by default from the dataset id, which it can be not the current users org. so the facet ideally should be the `requesting_organisation` field. 

now there will be an issue when user edit the data request, by default, the `organization_id` is hidden, and `requesting_organisation` is a list of current user's org, if user moved org, and try to edit the older data request from older org, the older org won't be visible on the list, and user can't save this data request edit form without selecting the available org list. and if user select the available org, the older org from the facet will be gone, because the data request is belongs to other `requesting_organisation`

I think we should have a quick discussion to align if this approach are right or not.