### PR TITLE
[QCDP24-26] revert back the facet to org id, and force show only the current users org

### DIFF
--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -30,7 +30,7 @@ from ckan import authz, model
 from ckan.lib import mailer
 from ckan.lib.redis import connect_to_redis
 from ckan.plugins import toolkit as tk
-from ckan.plugins.toolkit import h, config
+from ckan.plugins.toolkit import h, config, current_user
 
 from . import common, constants, db, validator
 
@@ -527,10 +527,10 @@ def list_datarequests(context, data_dict):
     tk.check_access(constants.LIST_DATAREQUESTS, context, data_dict)
 
     # Get the organization
-    requesting_organisation = data_dict.get('requesting_organisation', None)
-    if requesting_organisation:
+    organization_id = data_dict.get('organization_id', None)
+    if organization_id:
         # Get organization ID (organization name is received sometimes)
-        requesting_organisation = organization_show({'ignore_auth': True}, {'id': requesting_organisation}).get('id')
+        organization_id = organization_show({'ignore_auth': True}, {'id': organization_id}).get('id')
 
     user_id = data_dict.get('user_id', None)
     if user_id:
@@ -554,7 +554,7 @@ def list_datarequests(context, data_dict):
         desc = True
 
     # Call the function
-    db_datarequests = db.DataRequest.get_ordered_by_date(requesting_organisation=requesting_organisation,
+    db_datarequests = db.DataRequest.get_ordered_by_date(organization_id=organization_id,
                                                          user_id=user_id, status=status,
                                                          q=q, desc=desc, state=state)
 
@@ -575,24 +575,24 @@ def list_datarequests(context, data_dict):
         'Assign to Internal Data Catalogue Support': 0
     }
     for data_req in db_datarequests:
-        requesting_organisation = data_req.requesting_organisation
+        organization_id = data_req.organization_id
         status = data_req.status
 
-        if requesting_organisation:
-            no_processed_organization_facet[requesting_organisation] = no_processed_organization_facet.get(requesting_organisation, 0) + 1
+        if organization_id:
+            no_processed_organization_facet[organization_id] = no_processed_organization_facet.get(organization_id, 0) + 1
 
         if status in no_processed_status_facet:
             no_processed_status_facet[status] += 1
 
     # Format facets
-    requesting_organization_facet = []
-    for requesting_organisation in no_processed_organization_facet:
+    organization_facet = []
+    for organization_id in no_processed_organization_facet:
         try:
-            organization = organization_show({'ignore_auth': True}, {'id': requesting_organisation})
-            requesting_organization_facet.append({
+            organization = organization_show({'ignore_auth': True}, {'id': organization_id})
+            organization_facet.append({
                 'name': organization.get('name'),
                 'display_name': organization.get('display_name'),
-                'count': no_processed_organization_facet[requesting_organisation]
+                'count': no_processed_organization_facet[organization_id]
             })
         except Exception:
             pass
@@ -613,8 +613,14 @@ def list_datarequests(context, data_dict):
     }
 
     # Facets can only be included if they contain something
-    if requesting_organization_facet:
-        result['facets']['requesting_organisation'] = {'items': requesting_organization_facet}
+    if organization_facet:
+        # If not sysadmin, only show organizations where the current user is a member/editor/org admin.
+        if not current_user.sysadmin:
+            current_user_orgs = h.organizations_available('read')
+            user_orgs = {org['name'] for org in current_user_orgs}
+            organization_facet = [org for org in organization_facet if org['name'] in user_orgs]
+
+        result['facets']['organization'] = {'items': organization_facet}
 
     if status_facet:
         result['facets']['status'] = {'items': status_facet}

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -218,7 +218,8 @@ def _send_mail(action_type, datarequest, job_title=None, context=None, comment=N
 
         case 'update_datarequest':
             get_catalog_support_team()
-            get_datarequest_creator()
+            if current_user.id != datarequest['user_id']:
+                get_datarequest_creator()
 
         case 'comment_datarequest':
             get_catalog_support_team()
@@ -455,9 +456,7 @@ def update_datarequest(context, data_dict):
             break
 
     # Set the data provided by the user in the data_red
-    current_status = data_req.status
     _undictize_datarequest_basic(data_req, data_dict)
-    new_status = data_req.status
 
     # Always force datarequest to active state when updating, some older dataset may be in null state
     data_req.state = model.State.ACTIVE
@@ -467,12 +466,9 @@ def update_datarequest(context, data_dict):
 
     datarequest_dict = _dictize_datarequest(data_req)
 
-    if current_status != new_status:
-        _send_mail('update_datarequest', datarequest_dict, 'Data Request Status Change Email', context)
-        has_changes = True
-
     # Send follower and email notifications if there is changes in the data request
     if has_changes:
+        _send_mail('update_datarequest', datarequest_dict, 'Data Request Status Change Email', context)
         _send_mail('update_datarequest_follower', datarequest_dict, 'Data Request Updated Email', context)
 
     return datarequest_dict

--- a/ckanext/datarequests/auth.py
+++ b/ckanext/datarequests/auth.py
@@ -50,9 +50,9 @@ def show_datarequest(context, data_dict):
         if data_dict.get('user_id', None) == current_user.id:
             return {'success': True}
 
-        requesting_organisation = data_dict.get('requesting_organisation', None)
+        organization_id = data_dict.get('organization_id', None)
         current_user_orgs = [org['id'] for org in h.organizations_available('read')] or []
-        if requesting_organisation not in current_user_orgs:
+        if organization_id not in current_user_orgs:
             return {'success': False}
 
     return {'success': True}

--- a/ckanext/datarequests/controllers/controller_functions.py
+++ b/ckanext/datarequests/controllers/controller_functions.py
@@ -58,7 +58,7 @@ def _get_context():
             'user': c.user, 'auth_user_obj': c.userobj}
 
 
-def _show_index(user_id, requesting_organisation, include_organization_facet, url_func, file_to_render, extra_vars=None):
+def _show_index(user_id, organization_id, include_organization_facet, url_func, file_to_render, extra_vars=None):
     def pager_url(status=None, sort=None, q=None, page=None):
         params = []
 
@@ -88,8 +88,8 @@ def _show_index(user_id, requesting_organisation, include_organization_facet, ur
         if q:
             data_dict['q'] = q
 
-        if requesting_organisation:
-            data_dict['requesting_organisation'] = requesting_organisation
+        if organization_id:
+            data_dict['organization_id'] = organization_id
 
         if user_id:
             data_dict['user_id'] = user_id
@@ -105,7 +105,7 @@ def _show_index(user_id, requesting_organisation, include_organization_facet, ur
         c.filters = [(tk._('Newest'), 'desc'), (tk._('Oldest'), 'asc')]
         c.sort = sort
         c.q = q
-        c.requesting_organisation = requesting_organisation
+        c.organization = organization_id
         c.status = status
         c.datarequest_count = datarequests_list['count']
         c.datarequests = datarequests_list['result']
@@ -123,14 +123,14 @@ def _show_index(user_id, requesting_organisation, include_organization_facet, ur
 
         # Organization facet cannot be shown when the user is viewing an org
         if include_organization_facet is True:
-            c.facet_titles['requesting_organisation'] = tk._('Organizations')
+            c.facet_titles['organization'] = tk._('Organizations')
 
         if not extra_vars:
             extra_vars = {}
         extra_vars['filters'] = c.filters
         extra_vars['sort'] = c.sort
         extra_vars['q'] = c.q
-        extra_vars['requesting_organisation'] = c.requesting_organisation
+        extra_vars['organization'] = c.organization
         extra_vars['status'] = c.status
         extra_vars['datarequest_count'] = c.datarequest_count
         extra_vars['datarequests'] = c.datarequests
@@ -141,7 +141,7 @@ def _show_index(user_id, requesting_organisation, include_organization_facet, ur
             extra_vars['user'] = None
         if 'user_dict' not in extra_vars:
             extra_vars['user_dict'] = None
-        extra_vars['group_type'] = 'requesting_organisation'
+        extra_vars['group_type'] = 'organization'
         return tk.render(file_to_render, extra_vars=extra_vars)
     except ValueError as e:
         # This exception should only occur if the page value is not valid
@@ -153,7 +153,7 @@ def _show_index(user_id, requesting_organisation, include_organization_facet, ur
 
 
 def index():
-    return _show_index(None, request_helpers.get_first_query_param('requesting_organisation', ''), True, search_url,
+    return _show_index(None, request_helpers.get_first_query_param('organization', ''), True, search_url,
                        'datarequests/index.html')
 
 

--- a/ckanext/datarequests/db.py
+++ b/ckanext/datarequests/db.py
@@ -55,7 +55,7 @@ class DataRequest(model.core.StatefulObjectMixin, model.DomainObject):
         return query.filter(func.lower(cls.title) == func.lower(title)).first() is not None
 
     @classmethod
-    def get_ordered_by_date(cls, requesting_organisation=None, user_id=None, closed=None, q=None, desc=False, status=None, state=None):
+    def get_ordered_by_date(cls, organization_id=None, user_id=None, closed=None, q=None, desc=False, status=None, state=None):
         '''Personalized query'''
         query = model.Session.query(cls).autoflush(False)
         if state is None:
@@ -65,8 +65,8 @@ class DataRequest(model.core.StatefulObjectMixin, model.DomainObject):
 
         params = {}
 
-        if requesting_organisation is not None:
-            params['requesting_organisation'] = requesting_organisation
+        if organization_id is not None:
+            params['organization_id'] = organization_id
 
         if user_id is not None:
             params['user_id'] = user_id
@@ -88,27 +88,27 @@ class DataRequest(model.core.StatefulObjectMixin, model.DomainObject):
         # For sysadmins, we show all the data requests.
         restricted_org_id = None
 
-        # If it is regular user, and the requesting_organisation is not provided, filter it based on current user's organizations.
+        # If it is regular user, and the organization_id is not provided, filter it based on current user's organizations.
         if not current_user.sysadmin:
             current_user_orgs = h.organizations_available('read') or []
             restricted_org_id = [org['id'] for org in current_user_orgs]
 
-            if requesting_organisation is None:
-                # If the requesting_organisation is not provided, show the data requests created by the current user
+            if organization_id is None:
+                # If the organization_id is not provided, show the data requests created by the current user
                 # or all data request within the current user's organizations.
-                query = query.filter(or_(cls.user_id == current_user.id, cls.requesting_organisation.in_(restricted_org_id)))
+                query = query.filter(or_(cls.user_id == current_user.id, cls.organization_id.in_(restricted_org_id)))
             else:
-                if requesting_organisation not in restricted_org_id:
-                    # If the requesting_organisation is not within the current user's organizations,
+                if organization_id not in restricted_org_id:
+                    # If the organization_id is not within the current user's organizations,
                     # show only the data requests created by the current user.
                     query = query.filter(cls.user_id == current_user.id)
 
-                    # Remove the requesting_organisation from the filter.
-                    query = query.filter(cls.requesting_organisation is not None)
+                    # Remove the organization_id from the filter.
+                    query = query.filter(cls.organization_id is not None)
                 else:
-                    # Else the requesting_organisation is within the current user's organizations,
+                    # Else the organization_id is within the current user's organizations,
                     # show the data requests created by the current user or all data request within selected organization.
-                    query = query.filter(or_(cls.user_id == current_user.id, cls.requesting_organisation == requesting_organisation))
+                    query = query.filter(or_(cls.user_id == current_user.id, cls.organization_id == organization_id))
 
         current_user_id = current_user.id if current_user else None
         if current_user_id:

--- a/ckanext/datarequests/templates/datarequests/index.html
+++ b/ckanext/datarequests/templates/datarequests/index.html
@@ -4,7 +4,7 @@
   <section class="module">
     <div class="module-content">
       {% block page_primary_action %}
-        {% snippet 'snippets/custom_search_form.html', query=q, fields=(('requesting_organisation', requesting_organisation), ('state', state)), sorting=filters, sorting_selected=sort, placeholder=_('Search Data Requests...'), no_bottom_border=true, count=datarequest_count, no_title=True %}
+        {% snippet 'snippets/custom_search_form.html', query=q, fields=(('organization', organization), ('state', state)), sorting=filters, sorting_selected=sort, placeholder=_('Search Data Requests...'), no_bottom_border=true, count=datarequest_count, no_title=True %}
         {{ h.snippet('datarequests/snippets/datarequest_list.html', datarequest_count=datarequest_count, datarequests=datarequests, page=page, q=q)}}
       {% endblock %}
     </div>

--- a/ckanext/datarequests/templates/emails/bodies/update_datarequest.txt
+++ b/ckanext/datarequests/templates/emails/bodies/update_datarequest.txt
@@ -1,9 +1,9 @@
 An update on the following data access request has been submitted.
-To view the status of your data access request, follow this link: 
+To view the data access request, follow this link: 
 
 {{ site_url }}/datarequest/{{ datarequest.id }}
 
 Requested data: {{ datarequest.title }}
-Change of status: {{ datarequest.status }}
+Current of status: {{ datarequest.status }}
 
 Do not reply to this email.


### PR DESCRIPTION
https://salsadigital.atlassian.net/browse/QCDP24-26

Client confirmed below
- the facet needs to be the organization of the dataset of data request
- if current user request to other dataset that is not current user org, the org of that dataset will not appear on the facet.
- for sysadmin, it will show all the orgs.

another changes
https://salsadigital.atlassian.net/browse/QCDP24-19 
wording changes, and send out email on all fields edit, and exclude requestor if they edit their own data request